### PR TITLE
エラー文を日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,3 +74,5 @@ gem 'image_processing', '~> 1.2'
 gem 'active_hash'
 
 gem 'payjp'
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.4)
       loofah (~> 2.19, >= 2.19.1)
+    rails-i18n (7.0.6)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.0.6)
       actionpack (= 6.0.6)
       activesupport (= 6.0.6)
@@ -331,6 +334,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails (~> 4.0.0)
   rubocop
   sass-rails (~> 5)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -20,7 +20,7 @@ class Item < ApplicationRecord
     validates :item_price, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
   end
 
-    with_options numericality: { other_than: 0, message: "can't be blank or ---" } do
+    with_options numericality: { other_than: 0, message: 'を選択して下さい' } do
       validates :item_category_id
       validates :prefecture_id
       validates :item_condition_id

--- a/app/models/order_form.rb
+++ b/app/models/order_form.rb
@@ -7,11 +7,11 @@ class OrderForm
     validates :user_id
     validates :item_id
     # paymentモデルのバリデーション
-    validates :postal_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'is invalid. Include hyphen(-)' }
-    validates :prefecture_id, numericality: { other_than: 0, message: "can't be blank" }
+    validates :postal_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: ' が不正です。ハイフン(-)を含めてください' }
+    validates :prefecture_id, numericality: { other_than: 0, message: "を選択してください" }
     validates :city
     validates :address
-    validates :phone_number, format: { with: /\A[0-9]{10,11}\z/, message: 'is invalid' }
+    validates :phone_number, format: { with: /\A[0-9]{10,11}\z/, message: 'が不正です' }
     # トークンのバリデーション
     validates :token
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module Furima38809
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    config.i18n.default_locale = :ja
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,31 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        family_name: 名字
+        first_name: 名前
+        family_name_kana: 名字のフリガナ
+        first_name_kana: 名前のフリガナ
+        birth_day: 誕生日
+
+      item:
+        image: 画像
+        item_name: 出品商品名
+        item_description: 詳細
+        item_price: 値段
+        item_category_id: カテゴリー
+        prefecture_id: 都道府県
+        item_condition_id: 状態
+        payment_method_id: 発送料
+        delivery_time_id: 発送までの日数
+
+  activemodel:
+    attributes:
+      order_form:
+        postal_code: 郵便番号
+        prefecture_id: 都道府県
+        city: 市区町村
+        address: 番地
+        phone_number: 電話番号
+        token: カード情報

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -59,52 +59,52 @@ RSpec.describe Item, type: :model do
       it 'カテゴリーの情報が「---」だと出品できない' do
         @item.item_category_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item category can't be blank or ---")
+        expect(@item.errors.full_messages).to include("Item category を選択して下さい")
       end
       it 'カテゴリーの情報が空欄だと出品できない' do
         @item.item_category_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item category can't be blank or ---")
+        expect(@item.errors.full_messages).to include("Item category を選択して下さい")
       end
       it '商品の状態の情報が「---」だと出品できない' do
         @item.item_condition_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item condition can't be blank or ---")
+        expect(@item.errors.full_messages).to include("Item condition を選択して下さい")
       end
       it '商品の状態の情報が空欄だと出品できない' do
         @item.item_condition_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item condition can't be blank or ---")
+        expect(@item.errors.full_messages).to include("Item condition を選択して下さい")
       end
       it '配送料の負担の情報が「---」だと出品できない' do
         @item.payment_method_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include("Payment method can't be blank or ---")
+        expect(@item.errors.full_messages).to include("Payment method を選択して下さい")
       end
       it '配送料の負担の情報が空欄だと出品できない' do
         @item.payment_method_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Payment method can't be blank or ---")
+        expect(@item.errors.full_messages).to include("Payment method を選択して下さい")
       end
       it '発送元の地域の情報が「---」だと出品できない' do
         @item.prefecture_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture can't be blank or ---")
+        expect(@item.errors.full_messages).to include("Prefecture を選択して下さい")
       end
       it '発送元の地域の情報が空欄だと出品できない' do
         @item.prefecture_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture can't be blank or ---")
+        expect(@item.errors.full_messages).to include("Prefecture を選択して下さい")
       end
       it '発送までの日数の情報が「---」だと出品できない' do
         @item.delivery_time_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery time can't be blank or ---")
+        expect(@item.errors.full_messages).to include("Delivery time を選択して下さい")
       end
       it '発送までの日数の情報が空欄だと出品できない' do
         @item.delivery_time_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Delivery time can't be blank or ---")
+        expect(@item.errors.full_messages).to include("Delivery time を選択して下さい")
       end
       it '価格が空欄だと出品できない' do
         @item.item_price = nil

--- a/spec/models/order_form_spec.rb
+++ b/spec/models/order_form_spec.rb
@@ -65,12 +65,12 @@ RSpec.describe OrderForm, type: :model do
       it '郵便番号にハイフンがないと保存できない' do
         @order_form.postal_code = 1_234_567
         @order_form.valid?
-        expect(@order_form.errors.full_messages).to include('Postal code is invalid. Include hyphen(-)')
+        expect(@order_form.errors.full_messages).to include("Postal code  が不正です。ハイフン(-)を含めてください")
       end
       it '都道府県が「---」だと保存できない' do
         @order_form.prefecture_id = 0
         @order_form.valid?
-        expect(@order_form.errors.full_messages).to include("Prefecture can't be blank")
+        expect(@order_form.errors.full_messages).to include("Prefecture を選択してください")
       end
       it '都道府県が空だと保存できない' do
         @order_form.prefecture_id = nil
@@ -95,17 +95,17 @@ RSpec.describe OrderForm, type: :model do
       it '電話番号にハイフンがあると保存できない' do
         @order_form.phone_number = '123 - 1234 - 1234'
         @order_form.valid?
-        expect(@order_form.errors.full_messages).to include('Phone number is invalid')
+        expect(@order_form.errors.full_messages).to include("Phone number が不正です")
       end
       it '電話番号が12桁以上あると保存できない' do
         @order_form.phone_number = 12_345_678_910_123_111
         @order_form.valid?
-        expect(@order_form.errors.full_messages).to include('Phone number is invalid')
+        expect(@order_form.errors.full_messages).to include("Phone number が不正です")
       end
       it '電話番号が9桁以下では購入できない' do
         @order_form.phone_number = 123_456_789
         @order_form.valid?
-        expect(@order_form.errors.full_messages).to include('Phone number is invalid')
+        expect(@order_form.errors.full_messages).to include("Phone number が不正です")
       end
       it 'トークンが空だと保存できない' do
         @order_form.token = nil


### PR DESCRIPTION
what エラー文を日本語化
why ユーザーにわかりやすくエラー内容を伝えられるようにするため